### PR TITLE
Fix build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -47,4 +47,4 @@ ENV ANSIBLE_SSH_PIPELINING True
 ENV PATH /ansible/bin:$PATH
 ENV PYTHONPATH /ansible/lib
 
-ENTRYPOINT ["./ansible-playbook-wrapper"]
+ENTRYPOINT ["/bin/bash", "./ansible-playbook-wrapper"]

--- a/build/files/ansible-playbook-wrapper
+++ b/build/files/ansible-playbook-wrapper
@@ -18,7 +18,7 @@ if [ -z "${KEEPASS}" -a -r "${KEEPASS_FILE_CONFIG}" ]; then
 fi
 
 if [ -z "${KEEPASS}" ]; then
-  echo -n "Keepass file path (…servers.kdbx): "
+  echo -n "Keepass file path (${KEEPASS}): "
   read -r KEEPASS
 fi
 


### PR DESCRIPTION
Due to a missing script interpreter, the container is not able to run after building an image. This Pull Request fixes this behaviour.